### PR TITLE
Use StaticFile instead of Page

### DIFF
--- a/rssgenerator.rb
+++ b/rssgenerator.rb
@@ -21,7 +21,19 @@
 # Copyright Assaf Gelber 2014
 
 module Jekyll
-  class RssFeed < Page; end
+  class RssFeed < StaticFile
+    def initialize(site, base, dir, name, content)
+      @site = site
+      @base = base
+      @dir = dir
+      @name = name
+      @content = content
+    end
+
+    def write(dest)
+      File.open(destination(dest), "w") { |f| f.write(@content) }
+    end
+  end
 
   class RssGenerator < Generator
     priority :low
@@ -74,10 +86,8 @@ module Jekyll
       # So it should be safe to unescape the HTML.
       feed = CGI::unescapeHTML(rss.to_s)
 
-      File.open("#{full_path}#{rss_name}", "w") { |f| f.write(feed) }
-
       # Add the feed page to the site pages
-      site.pages << Jekyll::RssFeed.new(site, site.dest, rss_path, rss_name)
+      site.static_files << Jekyll::RssFeed.new(site, site.dest, rss_path, rss_name, feed)
     end
 
     private


### PR DESCRIPTION
If site.dest is outside site.source, Jekyll will append the path of a Page to the source-path and attempt to read it. So, if the source of our page is at /usr/src/www and we run `jekyll --destination=/tmp/www build`, the current code will write /tmp/www/rss.xml`, create a page with that as a source, then jekyll will try to override it with `/usr/src/www/tmp/www/rss.xml`, which doesn't exist and instead truncate the file.

Using `StaticFile` as a base, with a custom write-method avoids this problem.